### PR TITLE
Create VM based on image

### DIFF
--- a/app/models/foreman_kubevirt/kubevirt.rb
+++ b/app/models/foreman_kubevirt/kubevirt.rb
@@ -15,7 +15,7 @@ module ForemanKubevirt
     end
 
     def capabilities
-      [:build]
+      [:build, :image]
     end
 
     def provided_attributes
@@ -83,9 +83,15 @@ module ForemanKubevirt
       options = vm_instance_defaults.merge(args.to_hash.deep_symbolize_keys)
       logger.debug("creating VM with the following options: #{options.inspect}")
 
-      # FIXME provide an image based on user selection and cloud init
-      image = 'kubevirt/fedora-cloud-registry-disk-demo'
-      init = { 'userData' => "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin"}
+      if args["provision_method"] == "image"
+        image = args["image_id"]
+      else
+        # TODO: Support PVC
+        raise "Currently supports only image provisioning"
+      end
+
+      # FIXME Add cloud-init support
+      #init = { 'userData' => "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin"}
 
       interfaces = []
       networks = []

--- a/app/views/compute_resources_vms/form/kubevirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/kubevirt/_base.html.erb
@@ -9,12 +9,13 @@
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
 <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start'), :label_size => "col-md-2"} if new_vm && controller_name != "compute_attributes" %>
 
-<%
-   arch ||= nil ; os ||= nil
-   images = possible_images(compute_resource, arch, os)
--%>
 
-<% if false %>
+<% unless local_assigns[:hide_image] %>
+  <%
+     arch ||= nil ; os ||= nil
+     images = possible_images(compute_resource, arch, os)
+  -%>
+
   <div id='image_selection'>
     <%= select_f f, :image_id, images, :uuid, :name,
                  { :include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image') },

--- a/app/views/images/form/_kubevirt.html.erb
+++ b/app/views/images/form/_kubevirt.html.erb
@@ -1,4 +1,5 @@
 <%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
 <%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>
 <%= password_f f, :password, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>
-<%= image_field(f) %>
+<%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>
+<%= image_field(f, :label => _("Image"), :help_inline => _("The name of the image in the registry.")) %>


### PR DESCRIPTION
In order to create a VM based on image, the user should create an image
under Compute Resource --> Create Image, and provide the name of the
image on the registry.

The image will be set as the registryDisk of the vm (should be renamed
to containerDisk in a following PR).

One property of 'registryDisk' is missing ('path') and should be added
in a following PR as well