### PR TITLE
Support associate VM

### DIFF
--- a/app/models/foreman_kubevirt/kubevirt.rb
+++ b/app/models/foreman_kubevirt/kubevirt.rb
@@ -218,6 +218,10 @@ module ForemanKubevirt
       end
     end
 
+    def associated_host(vm)
+      associate_by("mac", vm.mac)
+    end
+
     # TODO: max supported values should be fetched according to namespace
     #      capabilities: kubectl get limits namespace_name
     def max_cpu_count


### PR DESCRIPTION
KubeVirt's VMs can be associated with Foreman's hosts by the 'mac'
property of the server (which represents the VM's mac address)