### PR TITLE
Use fog-kubevirt 0.20.0

### DIFF
--- a/foreman_kubevirt.gemspec
+++ b/foreman_kubevirt.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rubocop'
 
-  s.add_dependency('fog-kubevirt', '0.1.8')
+  s.add_dependency('fog-kubevirt', '0.2.0')
 end


### PR DESCRIPTION
fog-kubevirt supports kubevirt api v1alpha3 which contains recent API
changes.