### PR TITLE
Add Compute Resource API

### DIFF
--- a/app/controllers/foreman_kubevirt/concerns/api/compute_resources_controller_extensions.rb
+++ b/app/controllers/foreman_kubevirt/concerns/api/compute_resources_controller_extensions.rb
@@ -1,0 +1,34 @@
+module ForemanKubevirt
+ module Concerns
+    module Api::ComputeResourcesControllerExtensions
+      module ApiPieExtensions
+        extend ::Apipie::DSL::Concern
+        update_api(:create, :update) do
+          param :compute_resource, Hash do
+            param :token, String, :desc => N_("Token for KubeVirt only")
+            param :hostname, String, :desc => N_("Host name for KubeVirt only")
+            param :namespace, String, :desc => N_("Namespace for KubeVirt only")
+            param :ca_crt, String, :desc => N_("CA crt for KubeVirt only")
+            param :api_port, String, :desc => N_("API port for KubeVirt only")
+          end
+        end
+      end
+
+      extend ActiveSupport::Concern
+
+      included do
+        include ApiPieExtensions
+
+        def create
+          @compute_resource = ComputeResource.new_provider(compute_resource_params)
+          @compute_resource.test_connection
+          process_response @compute_resource.save
+        end
+
+        def update
+          process_response @compute_resource.update_attributes(compute_resource_params)
+        end
+      end
+    end
+  end
+end

--- a/app/views/api/v2/compute_resources/kubevirt.json.rabl
+++ b/app/views/api/v2/compute_resources/kubevirt.json.rabl
@@ -1,0 +1,1 @@
+attributes :hostname, :api_port, :namespace

--- a/lib/foreman_kubevirt/engine.rb
+++ b/lib/foreman_kubevirt/engine.rb
@@ -30,12 +30,20 @@ module ForemanKubevirt
       SETTINGS[:foreman_kubevirt] = { assets: { precompile: assets_to_precompile } }
     end
 
+    initializer "foreman_kubevirt.add_rabl_view_path" do
+      Rabl.configure do |config|
+        config.view_paths << ForemanKubevirt::Engine.root.join('app', 'views')
+      end
+    end
+
     # Include concerns in this config.to_prepare block
     config.to_prepare do
       begin
         require "fog/kubevirt"
         require "fog/compute/kubevirt/models/server"
         require File.expand_path("../../app/models/concerns/fog_extensions/kubevirt/server", __dir__)
+
+        ::Api::V2::ComputeResourcesController.send :include, ForemanKubevirt::Concerns::Api::ComputeResourcesControllerExtensions
         Fog::Compute::Kubevirt::Server.send(:include, ::FogExtensions::Kubevirt::Server)
 
         require "fog/compute/kubevirt/models/volume"


### PR DESCRIPTION
Example of creating a compute resource: 
```
POST http://localhost:3000/api/compute_resources/30
{
"compute_resource" : {
     "name" : "ssstam",
     "provider" : "KubeVirt",
     "hostname": "XXXX",
     "token":   "..." ,
     "namespace" : "default", 
     "api_port" : 8443
  }
}

```

Example of creating a host:
```
POST http://localhost:3000/api/hosts

{
  "location_id" : 1,
  "organization_id" : 2,
  "host" : {
    "name" : "dd",
    "location_id" : 1,
    "organization_id" : 2,
    "environment_id" : 1,
    "ip" : "192.168.124.31",
    "hostgroup_id" : 1,
    "compute_resource_id" : 30,
    "provision_method":"build",
    "compute_attributes" : {
      "cores" : "1",
      "volumes_attributes" : {"_delete":"", "id" :"", "name":"gluster-default-volume", "capacity":"1"}
    },
    "interfaces_attributes": {
       "0" : {"domain_id" : "1", "name" : "chase-prevett", "subnet_id" : "1",
              "ip" : "192.168.124.31", "managed" : "1", "primary" : "1", "provision" : "1",
              "type": "Nic::Managed", "virtual" : "0",
              "compute_attributes" : {"cni_provider":"multus", "network": "default"}
             }
    }
  }
}
```