### PR TITLE
Replace Boot VM from Network checkbox with primary

### DIFF
--- a/app/models/foreman_kubevirt/kubevirt.rb
+++ b/app/models/foreman_kubevirt/kubevirt.rb
@@ -164,7 +164,7 @@ module ForemanKubevirt
         end
 
         # TODO: Consider replacing with 'free' boot order, also verify uniqueness
-        nic[:bootOrder] = 1 if iface["boot"] == '1'
+        nic[:bootOrder] = 1 if iface["provision"] == true
         nic[:macAddress] = iface["mac"] if iface["mac"]
         interfaces << nic
         networks << net
@@ -223,7 +223,7 @@ module ForemanKubevirt
     #
     def host_interfaces_attrs(host)
       host.interfaces.select(&:physical?).each.with_index.reduce({}) do |hash, (nic, index)|
-        hash.merge(index.to_s => nic.compute_attributes.merge(ip: nic.ip, mac: nic.mac))
+        hash.merge(index.to_s => nic.compute_attributes.merge(ip: nic.ip, mac: nic.mac, provision: nic.provision))
       end
     end
 

--- a/app/views/compute_resources_vms/form/kubevirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/kubevirt/_network.html.erb
@@ -10,5 +10,3 @@
                 :label => _('Network'),
                 :label_size => "col-md-3" %>
 
-<%= checkbox_f f, :boot, :label => _('Boot From Network'), :label_size => "col-md-3" %>
-


### PR DESCRIPTION
The 'Boot VM from Network' shares the same behavior as the 'primary'
checkbox, therefore it could be removed and the functionality will be
based on the 'primary' network interface.