### PR TITLE
Support Storage Class when creating VM

### DIFF
--- a/app/assets/javascripts/compute_resources/kubevirt/volume.js
+++ b/app/assets/javascripts/compute_resources/kubevirt/volume.js
@@ -43,3 +43,14 @@ setPvcSize = function (pvc, pvcSizeMod) {
     pvcSizeMod.val(null);
   }
 }
+
+bootableRadio = function (item) {
+  const disabled = $('[id$=_bootable_true]:disabled:checked:visible');
+
+  $('[id$=_bootable_true]').prop('checked', false);
+  if (disabled.length > 0) {
+    disabled.prop('checked', true);
+  } else {
+    $(item).prop('checked', true);
+  }
+}

--- a/app/models/concerns/fog_extensions/kubevirt/volume.rb
+++ b/app/models/concerns/fog_extensions/kubevirt/volume.rb
@@ -3,6 +3,9 @@ module FogExtensions
     module Volume
       extend ActiveSupport::Concern
 
+      attr_accessor :storage_class
+      attr_accessor :capacity
+
       def id
         name
       end

--- a/app/models/foreman_kubevirt/kubevirt.rb
+++ b/app/models/foreman_kubevirt/kubevirt.rb
@@ -57,7 +57,7 @@ module ForemanKubevirt
     def networks
       nets = client.networkattachmentdefs
       # Add explicitly 'default' POD network
-      nets << Fog::Compute::Kubevirt::Networkattachmentdef.new(name: 'default')
+      nets << Fog::Kubevirt::Compute::Networkattachmentdef.new(name: 'default')
       nets
     end
 
@@ -81,7 +81,7 @@ module ForemanKubevirt
 
     def new_volume(attr = {})
       return unless new_volume_errors.empty?
-      Fog::Compute::Kubevirt::Volume.new(attr)
+      Fog::Kubevirt::Compute::Volume.new(attr)
     end
 
     def new_volume_errors
@@ -125,7 +125,7 @@ module ForemanKubevirt
 
       # Add image as volume to the virtual machine
       if args["provision_method"] == "image"
-        volume = Fog::Compute::Kubevirt::Volume.new
+        volume = Fog::Kubevirt::Compute::Volume.new
         image = args["image_id"]
         raise "VM should be created based on an image" unless image
 
@@ -227,7 +227,7 @@ module ForemanKubevirt
     def create_vm_volume(pvc_name, capacity, storage_class, bootable)
       pvc = create_new_pvc(pvc_name, capacity, storage_class)
 
-      volume = Fog::Compute::Kubevirt::Volume.new
+      volume = Fog::Kubevirt::Compute::Volume.new
       volume.type = 'persistentVolumeClaim'
       volume.info = pvc_name
       volume.boot_order = 1 if bootable == "true"
@@ -290,7 +290,7 @@ module ForemanKubevirt
     def client
       return @client if @client
 
-      @client ||= Fog::Compute.new(
+      @client ||= Fog::Kubevirt::Compute.new(
         :provider            => "kubevirt",
         :kubevirt_hostname   => hostname,
         :kubevirt_port       => api_port,

--- a/app/models/foreman_kubevirt/kubevirt.rb
+++ b/app/models/foreman_kubevirt/kubevirt.rb
@@ -24,9 +24,8 @@ module ForemanKubevirt
       attrs[:api_port] = key
     end
 
-
     def capabilities
-      [:build, :image]
+      [:build, :image, :new_volume]
     end
 
     def provided_attributes
@@ -72,22 +71,22 @@ module ForemanKubevirt
       client.volumes
     end
 
-    def available_volumes
-      volumes.select { |v| v.phase == 'Available' }
+    def storage_classes
+      client.storageclasses
     end
 
-    def volume_claims
-      client.pvcs
+    def storage_classes_for_select
+      storage_classes.map { |sc| OpenStruct.new({ id: sc.name, description: "#{sc.name} (#{sc.provisioner})" }) }
     end
 
     def new_volume(attr = {})
       return unless new_volume_errors.empty?
-      client.volumes.new(attr.merge(:capacity => '0G'))
+      Fog::Compute::Kubevirt::Volume.new(attr)
     end
 
     def new_volume_errors
       errors = []
-      errors.push _('no Persistent Volumes available on provider') if volumes.empty?
+      errors.push _('no Persistent Volumes available on provider') if storage_classes.empty?
       errors
     end
 
@@ -113,27 +112,38 @@ module ForemanKubevirt
     #             }
     #    }
     # volumes_attributes[Hash] - the attributes for the persistent volume claim:
-    #  If provided 'capacity' key, a new PVC will be created on volume with name
-    #  specified by 'name' key.
-    #  If provided only 'name', its value will be used as the PVC to servce as an
-    #  existing claim of the VM.
+    #    {
+    #      "storage_class" => "local-storage",
+    #      "name"          => "mypvc",
+    #      "capacity"      => "2",
+    #      "bootable"      => "true"
+    #    }
     def create_vm(args = {})
       options = vm_instance_defaults.merge(args.to_hash.deep_symbolize_keys)
       logger.debug("creating VM with the following options: #{options.inspect}")
+      volumes = []
 
+      # Add image as volume to the virtual machine
       if args["provision_method"] == "image"
+        volume = Fog::Compute::Kubevirt::Volume.new
         image = args["image_id"]
+        raise "VM should be created based on an image" unless image
+
+        volume.info = image
+        volume.type = 'containerDisk'
+        volumes << volume
       else
-        volume = args.dig(:volumes_attributes, :name)
-        pvc = args.dig(:volumes_attributes, :id)
-        raise "VM should be created based on Persistent Volume Claim or Image" unless (volume || pvc)
+        # Add PVC as volumes to the virtual machine
+        pvc_name = args.dig(:volumes_attributes, :name)
+        raise "VM should be created based on Persistent Volume Claim" unless pvc_name
+
+        capacity = args.dig(:volumes_attributes, :capacity)
+        storage_class = args.dig(:volumes_attributes, :storage_class)
+        bootable = args.dig(:volumes_attributes, :bootable)
 
         # TODO: This supports a single PVC, but user might require for multiple pvcs
-        if pvc.blank?
-          capacity = args.dig(:volumes_attributes, :capacity)
-          pvc = options[:name].gsub(/[._]+/,'-') + "-pvc-01"
-          create_new_pvc(volume, capacity, pvc)
-        end
+        volume = create_vm_volume(pvc_name, capacity, storage_class, bootable)
+        volumes << volume
       end
 
       # FIXME Add cloud-init support
@@ -164,7 +174,14 @@ module ForemanKubevirt
         end
 
         # TODO: Consider replacing with 'free' boot order, also verify uniqueness
-        nic[:bootOrder] = 1 if iface["provision"] == true
+        # there is a bug with bootOrder https://bugzilla.redhat.com/show_bug.cgi?id=1687341
+        # therefore adding to the condition not to boot from netwotk device if already asked
+        # to boot from disk
+        nic[:bootOrder] = if iface["provision"] == true && volumes.select { |v| v.boot_order == 1}.empty?
+                            1
+                          else
+                            2
+                          end
         nic[:macAddress] = iface["mac"] if iface["mac"]
         interfaces << nic
         networks << net
@@ -174,25 +191,22 @@ module ForemanKubevirt
         client.vms.create(:vm_name     => options[:name],
                           :cpus        => options[:cpu_cores].to_i,
                           :memory_size => options[:memory].to_i / 2**20,
-                          :image       => image,
-                          :pvc         => pvc,
+                          :volumes     => volumes,
                           # :cloudinit   => init,
                           :networks    => networks,
                           :interfaces  => interfaces)
         client.servers.get(options[:name])
       rescue Fog::Kubevirt::Errors::ClientError => e
-        delete_pvc_by_name(pvc)
+        delete_pvc_by_name(pvc_name)
         raise e
       end
     end
 
-    def create_new_pvc(volume_name, capacity, pvc_name)
-      volume = volumes.get(volume_name)
+    def create_new_pvc(pvc_name, capacity, storage_class)
       client.pvcs.create(:name          => pvc_name,
                          :namespace     => namespace,
-                         :access_modes  => volume.access_modes,
-                         :volume_name   => volume.name,
-                         :storage_class => volume.storage_class,
+                         :storage_class => storage_class,
+                         :access_modes  => [ 'ReadWriteOnce' ],
                          :requests      => { :storage => capacity + "G" })
     end
 
@@ -208,6 +222,16 @@ module ForemanKubevirt
           logger.error("The PVC #{volume.info} couldn't be delete due to #{e.message}")
         end
       end
+    end
+
+    def create_vm_volume(pvc_name, capacity, storage_class, bootable)
+      pvc = create_new_pvc(pvc_name, capacity, storage_class)
+
+      volume = Fog::Compute::Kubevirt::Volume.new
+      volume.type = 'persistentVolumeClaim'
+      volume.info = pvc_name
+      volume.boot_order = 1 if bootable == "true"
+      volume
     end
 
     def destroy_vm(uuid)

--- a/app/views/compute_resources_vms/form/kubevirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/kubevirt/_volume.html.erb
@@ -1,16 +1,21 @@
-<% claims = compute_resource.volume_claims %>
-<%= select_f f, :id,
-               claims,
-               :attributes,
-               :name,
-               { :include_blank => _("Create New Claim") },
-               :label => _('Persistent Volume Claim'),
-               :label_size => "col-md-2",
-               :disabled => !new_vm,
-               :onchange    => 'pvcSelected(this);',
-               :class => "col-md-2 pvc-name" %>
+<% storage_classes = compute_resource.storage_classes %>
 
-<%= select_f f, :name, compute_resource.available_volumes, :attributes, :name,
-               { }, :label => _('Persistent Volume'), :label_size => "col-md-2", :disabled => !new_vm, :class => "col-md-2 pvc-selected-volume" %>
+<%= select_f f, :storage_class,
+                compute_resource.storage_classes_for_select,
+                :id,
+                :description,
+                { },
+                :label => _('Storage Class'),
+                :label_size => "col-md-2",
+                :disabled => !new_vm,
+                :class => "col-md-2" %>
+
+<%= text_f f,:name, :label => _('Claim Name'), :value => "", :label_size => "col-md-2", :disabled => !new_vm, :class => "col-md-2 pvc-name" %>
 
 <%= text_f f,:capacity, :label => _('Size (GB)'), :value => "", :label_size => "col-md-2", :disabled => !new_vm, :class => "col-md-2 pvc-size" %>
+
+<% bootable = false %>
+<%= field(f, :bootable, :label => _('Bootable'), :label_size => "col-md-2") do
+  radio_button_f f, :bootable, {:disabled => !new_vm, :value=> 'true', :checked => bootable == 'true', :onclick => 'bootableRadio(this)',
+  :text => _('Only one volume can be bootable')}
+end %>

--- a/foreman_kubevirt.gemspec
+++ b/foreman_kubevirt.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rubocop'
 
-  s.add_dependency('fog-kubevirt', '0.2.1')
+  s.add_dependency('fog-kubevirt', '1.1.0')
 end

--- a/lib/foreman_kubevirt/engine.rb
+++ b/lib/foreman_kubevirt/engine.rb
@@ -44,19 +44,19 @@ module ForemanKubevirt
     config.to_prepare do
       begin
         require "fog/kubevirt"
-        require "fog/compute/kubevirt/models/server"
+        require "fog/kubevirt/compute/models/server"
         require File.expand_path("../../app/models/concerns/fog_extensions/kubevirt/server", __dir__)
 
         ::Api::V2::ComputeResourcesController.send :include, ForemanKubevirt::Concerns::Api::ComputeResourcesControllerExtensions
-        Fog::Compute::Kubevirt::Server.send(:include, ::FogExtensions::Kubevirt::Server)
+        Fog::Kubevirt::Compute::Server.send(:include, ::FogExtensions::Kubevirt::Server)
 
-        require "fog/compute/kubevirt/models/volume"
+        require "fog/kubevirt/compute/models/volume"
         require File.expand_path("../../app/models/concerns/fog_extensions/kubevirt/volume", __dir__)
-        Fog::Compute::Kubevirt::Volume.send(:include, ::FogExtensions::Kubevirt::Volume)
+        Fog::Kubevirt::Compute::Volume.send(:include, ::FogExtensions::Kubevirt::Volume)
 
-        require "fog/compute/kubevirt/models/pvc"
+        require "fog/kubevirt/compute/models/pvc"
         require File.expand_path("../../app/models/concerns/fog_extensions/kubevirt/pvc", __dir__)
-        Fog::Compute::Kubevirt::Pvc.send(:include, ::FogExtensions::Kubevirt::Pvc)
+        Fog::Kubevirt::Compute::Pvc.send(:include, ::FogExtensions::Kubevirt::Pvc)
       rescue StandardError => e
         Rails.logger.warn "Foreman-Kubevirt: skipping engine hook (#{e})"
       end


### PR DESCRIPTION
This PR depends on https://github.com/fog/fog-kubevirt/pull/82

The Storage dialog under the Virtual Machine tab of 'Create Host' was changed.
Its new look is:
![Selection_999(218)](https://user-images.githubusercontent.com/316242/54987390-31893680-4fbd-11e9-877f-cbe70c31687a.png)

This PR depends on fog-kubevirt's PR: https://github.com/fog/fog-kubevirt/pull/83