### PR TITLE
Do not run tests by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ Or by retrieving from the secret of service account *my-account* under the *defa
 # kubectl get secret $KUBE_SECRET -n default -o jsonpath='{.data.ca\.crt}' | base64 -d
 ```
 
+## Tests
+
+Tests should be invoked from the *foreman* directory by:
+```
+# bundle exec rake test:foreman_kubevirt
+```
+
 ## TODO
 
 * Implement VM Console

--- a/Rakefile
+++ b/Rakefile
@@ -32,8 +32,6 @@ Rake::TestTask.new(:test) do |t|
   t.verbose = false
 end
 
-task default: :test
-
 begin
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new


### PR DESCRIPTION
Tests should be executed from the foreman directory since they rely on
resources exist on that repository.

Therefore the default task of Rake shouldn't invoke the tests.