### PR TITLE
Support compute profiles

### DIFF
--- a/app/models/concerns/fog_extensions/kubevirt/volume.rb
+++ b/app/models/concerns/fog_extensions/kubevirt/volume.rb
@@ -2,18 +2,6 @@ module FogExtensions
   module Kubevirt
     module Volume
       extend ActiveSupport::Concern
-
-      attr_writer :storage_class
-      attr_writer :capacity
-
-      def capacity
-        pvc.requests[:storage] unless pvc.nil?
-      end
-
-      def storage_class
-        pvc&.storage_class
-      end
-
       def bootable
         boot_order == 1
       end

--- a/app/models/foreman_kubevirt/kubevirt.rb
+++ b/app/models/foreman_kubevirt/kubevirt.rb
@@ -83,7 +83,9 @@ module ForemanKubevirt
     def new_volume(attr = {})
       return unless new_volume_errors.empty?
 
-      Fog::Kubevirt::Compute::Volume.new(attr)
+      vol = Fog::Kubevirt::Compute::Volume.new(attr)
+      vol.boot_order = 1 if attr[:bootable] == "on" || attr[:bootable] == "true"
+      vol
     end
 
     def new_volume_errors
@@ -314,6 +316,15 @@ module ForemanKubevirt
       end
 
       vm_attrs
+    end
+
+    def new_vm(attr = {})
+      vm = super
+      interfaces = nested_attributes_for :interfaces, attr[:interfaces_attributes]
+      interfaces.map { |i| vm.interfaces << new_interface(i)}
+      volumes = nested_attributes_for :volumes, attr[:volumes_attributes]
+      volumes.map { |v| vm.volumes << new_volume(v) }
+      vm
     end
 
     def associated_host(vm)


### PR DESCRIPTION
In order to support compute profile, new_vm and new_volume should be
implemented properly.

This PR depends on fog/fog-kubevirt#118 which included in fog-kubevirt-1.2.4